### PR TITLE
update settings to support scaffolding with Vue CLI 4

### DIFF
--- a/generator/template/babel.config.js
+++ b/generator/template/babel.config.js
@@ -5,7 +5,7 @@ module.exports = {
       '@vue/app',
       {
         polyfills: [
-          'es6.promise'
+          'es.promise'
         ]
       },
     ],

--- a/generator/template/vue.config.js
+++ b/generator/template/vue.config.js
@@ -4,7 +4,7 @@ module.exports = {
   css: {
     loaderOptions: {
       sass: {
-        data: '@import "@/styles/_variables.scss";'
+        prependData: '@import "@/styles/_variables.scss";'
       }
     }
   }


### PR DESCRIPTION
The `data` option in `vue.config.js` was deprecated and replaced with `prependData`.
The name of the promise polyfill has been changed.